### PR TITLE
upgrade to pillow >= 1.0

### DIFF
--- a/Blit/__init__.py
+++ b/Blit/__init__.py
@@ -21,7 +21,7 @@ and Blit.photoshop for PSD file output support.
 __version__ = 'N.N.N'
 
 import numpy
-import Image
+from PIL import Image
 
 from . import blends
 from . import adjustments

--- a/Blit/photoshop.py
+++ b/Blit/photoshop.py
@@ -18,7 +18,7 @@ Photoshop is a registered trademark of Adobe Corporation.
 from struct import pack
 
 import numpy
-import Image
+from PIL import Image
 
 from . import Layer
 from . import utils

--- a/Blit/tests.py
+++ b/Blit/tests.py
@@ -4,14 +4,14 @@ Run as a module, like this:
     python -m Blit.tests
 """
 import unittest
-import Image
+from PIL import Image
 
 from . import Bitmap, Color, Layer, blends, adjustments, utils, photoshop
 
 def _str2img(str):
     """
     """
-    return Image.fromstring('RGBA', (3, 3), str)
+    return Image.frombytes('RGBA', (3, 3), str)
 
 class Tests(unittest.TestCase):
 

--- a/Blit/utils.py
+++ b/Blit/utils.py
@@ -1,16 +1,16 @@
 import numpy
-import Image
+from PIL import Image
 
 def arr2img(ar):
     """ Convert Numeric array to PIL Image.
     """
-    return Image.fromstring('L', (ar.shape[1], ar.shape[0]), ar.astype(numpy.ubyte).tostring())
+    return Image.frombytes('L', (ar.shape[1], ar.shape[0]), ar.astype(numpy.ubyte).tobytes())
 
 def img2arr(im):
     """ Convert PIL Image to Numeric array.
     """
     assert im.mode == 'L'
-    return numpy.reshape(numpy.fromstring(im.tostring(), numpy.ubyte), (im.size[1], im.size[0]))
+    return numpy.reshape(numpy.fromstring(im.tobytes(), numpy.ubyte), (im.size[1], im.size[0]))
 
 def chan2img(chan):
     """ Convert single Numeric array object to one-channel PIL Image.


### PR DESCRIPTION
I had a problem using this library and tilestache to get a map rendered and the problem was that mi python-pillow version had depercated two things:
- `import Image`
- `Image.(to|from)string()`
